### PR TITLE
Add directed variants for attribute and triangle terms

### DIFF
--- a/R/tabulergm_table.R
+++ b/R/tabulergm_table.R
@@ -664,14 +664,12 @@ tabulergm_table.formula <- function(
 #' @export
 #' @seealso [tabulergm_table()]
 #' @examples
-#' \dontrun{
 #' library(ergm)
 #' fit <- readRDS(system.file("fits", "fit_edges.rds", package = "tabulergm"))
 #' tabulergm_view(fit)
 #'
 #' # Also works with a formula (shows term metadata only)
 #' tabulergm_view(network ~ edges + triangle)
-#' }
 tabulergm_view <- function(object, ...) {
   UseMethod("tabulergm_view")
 }

--- a/R/term_db.R
+++ b/R/term_db.R
@@ -37,7 +37,6 @@
 #' @export
 #' @seealso [tabulergm_set_plotfun()], [tabulergm_get_plotfun()]
 #' @examples
-#' \dontrun{
 #' # See the default implementation
 #' tabulergm_default_plotfun
 #'
@@ -46,8 +45,10 @@
 #'   netplot::nplot(netobj, vertex.color = vcolor, edge.color = ecolor,
 #'                  layout = layout)
 #' }
+#' old <- tabulergm_get_plotfun()
 #' tabulergm_set_plotfun(my_plotfun)
-#' }
+#' # Restore the previous plot function
+#' tabulergm_set_plotfun(old)
 tabulergm_default_plotfun <- function(
   netobj,
   layout,
@@ -110,15 +111,14 @@ tabulergm_default_plotfun <- function(
 #' @export
 #' @seealso [tabulergm_default_plotfun()], [tabulergm_get_plotfun()]
 #' @examples
-#' \dontrun{
 #' my_plotfun <- function(netobj, layout, vcolor, ecolor, directed, ...) {
 #'   netplot::nplot(netobj, vertex.color = vcolor, edge.color = ecolor,
 #'                  layout = layout)
 #' }
-#' old <- tabulergm_set_plotfun(my_plotfun)
-#' # Restore the default
-#' tabulergm_set_plotfun(tabulergm_default_plotfun)
-#' }
+#' old <- tabulergm_get_plotfun()
+#' tabulergm_set_plotfun(my_plotfun)
+#' # Restore the previous plot function
+#' tabulergm_set_plotfun(old)
 tabulergm_set_plotfun <- function(plotfun) {
   if (!is.function(plotfun)) {
     stop("'plotfun' must be a function.", call. = FALSE)

--- a/inst/terms/absdiff.directed.yml
+++ b/inst/terms/absdiff.directed.yml
@@ -1,0 +1,10 @@
+plot:
+  edgelist: "0->1"
+  vcolor: [orange, orange]
+  vsize: [1.0, .5]
+  ecolor: black
+  layout:
+    x: [0, 1]
+    y: [0, 0]
+math: |
+  \sum_{i \neq j} y_{ij} \left|x_i - x_j\right|

--- a/inst/terms/edgecov.directed.yml
+++ b/inst/terms/edgecov.directed.yml
@@ -1,0 +1,10 @@
+plot:
+  edgelist: "0->1"
+  vcolor: [gray, gray]
+  ecolor: orange
+  elinetype: [2]
+  layout:
+    x: [0, 1]
+    y: [0, 0]
+math: |
+  \sum_{i \neq j} y_{ij} x_{ij}

--- a/inst/terms/nodecov.directed.yml
+++ b/inst/terms/nodecov.directed.yml
@@ -1,0 +1,10 @@
+plot:
+  edgelist: "0->1"
+  vcolor: [orange, orange]
+  vsize: [1.0, .6]
+  ecolor: black
+  layout:
+    x: [0, 1]
+    y: [0, 0]
+math: |
+  \sum_{i \neq j} y_{ij} (x_i + x_j)

--- a/inst/terms/nodefactor.directed.yml
+++ b/inst/terms/nodefactor.directed.yml
@@ -1,0 +1,10 @@
+plot:
+  edgelist: "0->1, 2->0, 0->3"
+  vcolor: [orange, gray, gray, gray]
+  vsize: [1.0, .5, .5, .5]
+  ecolor: black
+  layout:
+    x: [0, 1, 1, 1]
+    y: [0, .5, 0, -.5]
+math: |
+  \sum_{i \neq j} y_{ij} \left[\mathbf{1}(x_i = k) + \mathbf{1}(x_j = k)\right]

--- a/inst/terms/nodematch.directed.yml
+++ b/inst/terms/nodematch.directed.yml
@@ -1,0 +1,11 @@
+plot:
+  edgelist: "0->1"
+  vcolor:
+    - orange
+    - orange
+  ecolor: black
+  layout:
+    x: [0, 1]
+    y: [0, 0]
+math: |
+  \sum_{i \neq j} y_{ij} \mathbf{1}(x_i = x_j)

--- a/inst/terms/nodemix.directed.yml
+++ b/inst/terms/nodemix.directed.yml
@@ -1,0 +1,9 @@
+plot:
+  edgelist: "0->1"
+  vcolor: [orange, "#008080"]
+  ecolor: black
+  layout:
+    x: [0, 1]
+    y: [0, 0]
+math: |
+  \sum_{i \neq j} y_{ij} \mathbf{1}(x_i = k, x_j = l)

--- a/inst/terms/triangle.directed.yml
+++ b/inst/terms/triangle.directed.yml
@@ -1,0 +1,9 @@
+plot:
+  edgelist: "0->1->2, 0->2"
+  vcolor: black
+  ecolor: black
+  layout:
+    x: [0, 0.5, 1]
+    y: [0, 1, 0]
+math: |
+  \sum_{i \neq j \neq k} y_{ij} y_{jk} y_{ik} + \frac{1}{3} \sum_{i \neq j \neq k} y_{ij} y_{jk} y_{ki}

--- a/inst/tinytest/test_term_db.R
+++ b/inst/tinytest/test_term_db.R
@@ -59,10 +59,18 @@ yml_test_cases <- list(
   list(term = "gwdegree", directed = FALSE, pattern = "gwdegree\\.undirected\\.yml$"),
   list(term = "altkstar", directed = FALSE, pattern = "altkstar\\.undirected\\.yml$"),
   list(term = "nodefactor", directed = FALSE, pattern = "nodefactor\\.undirected\\.yml$"),
+  list(term = "nodefactor", directed = TRUE,  pattern = "nodefactor\\.directed\\.yml$"),
   list(term = "nodecov", directed = FALSE, pattern = "nodecov\\.undirected\\.yml$"),
+  list(term = "nodecov", directed = TRUE,  pattern = "nodecov\\.directed\\.yml$"),
   list(term = "absdiff", directed = FALSE, pattern = "absdiff\\.undirected\\.yml$"),
+  list(term = "absdiff", directed = TRUE,  pattern = "absdiff\\.directed\\.yml$"),
   list(term = "nodemix", directed = FALSE, pattern = "nodemix\\.undirected\\.yml$"),
+  list(term = "nodemix", directed = TRUE,  pattern = "nodemix\\.directed\\.yml$"),
   list(term = "edgecov", directed = FALSE, pattern = "edgecov\\.undirected\\.yml$"),
+  list(term = "edgecov", directed = TRUE,  pattern = "edgecov\\.directed\\.yml$"),
+  list(term = "nodematch", directed = FALSE, pattern = "nodematch\\.undirected\\.yml$"),
+  list(term = "nodematch", directed = TRUE,  pattern = "nodematch\\.directed\\.yml$"),
+  list(term = "triangle", directed = TRUE,  pattern = "triangle\\.directed\\.yml$"),
   list(term = "transitiveties", directed = TRUE, pattern = "transitiveties\\.directed\\.yml$"),
   list(term = "cyclicalties", directed = TRUE, pattern = "cyclicalties\\.directed\\.yml$"),
   list(term = "nodeicov", directed = TRUE, pattern = "nodeicov\\.directed\\.yml$"),
@@ -132,7 +140,8 @@ for (term in c("gwesp", "gwdsp", "gwdegree", "altkstar", "nodefactor",
 
 # .get_term_yml_data reads directed key term math and figures
 for (term in c("gwesp", "gwdsp", "transitiveties", "cyclicalties",
-               "nodeicov", "nodeocov")) {
+               "nodeicov", "nodeocov", "nodematch", "absdiff", "nodecov",
+               "nodefactor", "nodemix", "edgecov", "triangle")) {
   data <- tabulergm:::.get_term_yml_data(term, directed = TRUE)
   expect_false(is.na(data$math),
     info = sprintf("math found for %s (directed)", term))
@@ -329,6 +338,34 @@ local({
 })
 
 
+# .draw_term_figure passes directedness through to the plot function via
+# both the `directed` argument and the network object itself, so plot
+# functions (e.g. netplot, which adds arrowheads only for directed
+# networks) can draw edges accordingly
+local({
+  captured <- new.env(parent = emptyenv())
+  custom <- function(netobj, layout, vcolor, ecolor, directed, ...) {
+    captured$directed_arg <- directed
+    captured$directed_net <- network::is.directed(netobj)
+    invisible(NULL)
+  }
+  old <- tabulergm_set_plotfun(custom)
+  on.exit(tabulergm_set_plotfun(old), add = TRUE)
+
+  spec <- list(edgelist = "0->1", vcolor = "black", ecolor = "black")
+
+  tabulergm:::.draw_term_figure(spec, directed = TRUE,
+                                outfile = tempfile(fileext = ".png"))
+  expect_true(captured$directed_arg)
+  expect_true(captured$directed_net)
+
+  tabulergm:::.draw_term_figure(spec, directed = FALSE,
+                                outfile = tempfile(fileext = ".png"))
+  expect_false(captured$directed_arg)
+  expect_false(captured$directed_net)
+})
+
+
 # ---- Integration with parse_ergm_formula -------------------------------------
 
 # parse_ergm_formula populates math from YAML for known terms
@@ -384,6 +421,21 @@ result6 <- parse_ergm_formula(f6)
 for (term in c("transitiveties", "cyclicalties", "nodeicov", "nodeocov")) {
   expect_false(is.na(result6$math[result6$term == term]),
     info = sprintf("formula math found for %s", term))
+}
+
+# Attribute and structural terms resolve on directed networks too
+nw_formula_attr <- network::network.initialize(5, directed = TRUE)
+f7 <- nw_formula_attr ~ nodematch("a") + absdiff("a") + nodecov("a") +
+  nodefactor("a") + nodemix("a") + edgecov("d") + triangle
+result7 <- parse_ergm_formula(f7)
+for (term in c("nodematch", "absdiff", "nodecov", "nodefactor",
+               "nodemix", "edgecov", "triangle")) {
+  expect_false(is.na(result7$math[result7$term == term]),
+    info = sprintf("formula math found for %s (directed)", term))
+  expect_false(is.na(result7$figure[result7$term == term]),
+    info = sprintf("formula figure found for %s (directed)", term))
+  expect_true(grepl("neq", result7$math[result7$term == term]),
+    info = sprintf("directed math (ordered pairs) used for %s", term))
 }
 
 # Explicit directedness selects the matching YAML variant

--- a/man/tabulergm_default_plotfun.Rd
+++ b/man/tabulergm_default_plotfun.Rd
@@ -52,7 +52,6 @@ A plot function must accept the arguments \code{netobj}, \code{layout}, \code{vc
 \code{ecolor}, \code{directed}, and \code{...}, and draw on the current graphics device.
 }
 \examples{
-\dontrun{
 # See the default implementation
 tabulergm_default_plotfun
 
@@ -61,8 +60,10 @@ my_plotfun <- function(netobj, layout, vcolor, ecolor, directed, vshape, vrotati
   netplot::nplot(netobj, vertex.color = vcolor, edge.color = ecolor,
                  layout = layout)
 }
+old <- tabulergm_get_plotfun()
 tabulergm_set_plotfun(my_plotfun)
-}
+# Restore the previous plot function
+tabulergm_set_plotfun(old)
 }
 \seealso{
 \code{\link[=tabulergm_set_plotfun]{tabulergm_set_plotfun()}}, \code{\link[=tabulergm_get_plotfun]{tabulergm_get_plotfun()}}

--- a/man/tabulergm_set_plotfun.Rd
+++ b/man/tabulergm_set_plotfun.Rd
@@ -20,15 +20,14 @@ The function must accept \code{netobj}, \code{layout}, \code{vcolor}, \code{ecol
 cached term figures, so subsequent renders use the new function.
 }
 \examples{
-\dontrun{
 my_plotfun <- function(netobj, layout, vcolor, ecolor, directed, ...) {
   netplot::nplot(netobj, vertex.color = vcolor, edge.color = ecolor,
                  layout = layout)
 }
-old <- tabulergm_set_plotfun(my_plotfun)
-# Restore the default
-tabulergm_set_plotfun(tabulergm_default_plotfun)
-}
+old <- tabulergm_get_plotfun()
+tabulergm_set_plotfun(my_plotfun)
+# Restore the previous plot function
+tabulergm_set_plotfun(old)
 }
 \seealso{
 \code{\link[=tabulergm_default_plotfun]{tabulergm_default_plotfun()}}, \code{\link[=tabulergm_get_plotfun]{tabulergm_get_plotfun()}}

--- a/man/tabulergm_view.Rd
+++ b/man/tabulergm_view.Rd
@@ -34,14 +34,12 @@ viewer pane when available, falling back to \code{\link[utils:browseURL]{utils::
 
 }}
 \examples{
-\dontrun{
 library(ergm)
 fit <- readRDS(system.file("fits", "fit_edges.rds", package = "tabulergm"))
 tabulergm_view(fit)
 
 # Also works with a formula (shows term metadata only)
 tabulergm_view(network ~ edges + triangle)
-}
 }
 \seealso{
 \code{\link[=tabulergm_table]{tabulergm_table()}}


### PR DESCRIPTION
## Problem

`nodematch` (and several other terms) produced no math or figure when used with a directed network:

```r
nw <- network.initialize(5, directed = TRUE)
nw %v% "gender" <- c("a", "b", "a", "b", "a")
parse_ergm_formula(nw ~ edges + nodematch("gender"))
# nodematch row: math = NA, figure = NA
```

The term database only shipped `.undirected.yml` entries for these terms, so the directed lookup in `.find_term_yml()` came up empty.

## What terms were added

Cross-checked every term already in `inst/terms/` against `ergm::search.ergmTerms()`: seven of them are tagged `directed` in the ergm term database (most also `frequently-used`) but had no directed entry here. This PR adds `.directed.yml` variants for:

| Term | Directed math |
|---|---|
| `nodematch` | sum over ordered pairs i ≠ j of 1(x_i = x_j) |
| `absdiff` | \|x_i − x_j\| over i ≠ j |
| `nodecov` | (x_i + x_j) over i ≠ j |
| `nodefactor` | indicator sum over i ≠ j |
| `nodemix` | ordered-pair mixing 1(x_i = k, x_j = l) |
| `edgecov` | x_ij over i ≠ j |
| `triangle` | transitive + cyclic triples, per ergm's directed definition |

`gwdegree` and `altkstar` were deliberately left undirected-only — that matches ergm (their directed counterparts are separate terms such as `gwidegree`/`gwodegree`).

## Plotting

The plot pipeline already honors directedness: `.draw_term_figure()` builds the term network with `directed = TRUE`, and `netplot::nplot()` then draws arrowheads at the edge ends automatically (`skip.arrows = !network::is.directed(x)`). Verified visually — the new directed figures render with arrows. A new regression test asserts the plot function receives both `directed = TRUE` and a directed network object. The `nodefactor` directed figure shows mixed incoming/outgoing edges at the focal node since the statistic counts both.

## Tests

- YAML lookup cases for all seven new files (plus previously untested `nodematch`/`triangle` undirected lookups)
- Directed math + figure rendering for the new variants
- Formula-integration test on a directed network checking ordered-pair (`\neq`) math is selected
- Plot-function directedness regression test

Full suite: **All ok, 413 results**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)